### PR TITLE
Fixes/added-multiple-domains-support_changed-popup-height_fixed-invalid-return-type-error

### DIFF
--- a/Controller/AbstractSocial.php
+++ b/Controller/AbstractSocial.php
@@ -183,6 +183,7 @@ abstract class AbstractSocial extends Action
 				}
 				window.close();
 			</script>";
+		die;
 	}
 
 	/**

--- a/Controller/Google/Login.php
+++ b/Controller/Google/Login.php
@@ -17,7 +17,7 @@ class Login extends AbstractSocial
 
 		$customer = $this->checkCustomer($user_profile->identifier);
 		if (!$customer || !$customer->getId()) {
-			$name     = $user_profile->displayName;
+			$name     = ($user_profile->displayName)? $user_profile->displayName : __('NewUser');
 			$user     = [
 				'email'      => $user_profile->email,
 				'firstname'  => $user_profile->firstName ?: $name,

--- a/Controller/Google/Login.php
+++ b/Controller/Google/Login.php
@@ -17,7 +17,7 @@ class Login extends AbstractSocial
 
 		$customer = $this->checkCustomer($user_profile->identifier);
 		if (!$customer || !$customer->getId()) {
-			$name     = ($user_profile->displayName)? $user_profile->displayName : __('NewUser');
+			$name     = ($user_profile->displayName)? $user_profile->displayName : __('Default');
 			$user     = [
 				'email'      => $user_profile->email,
 				'firstname'  => $user_profile->firstName ?: $name,

--- a/Helper/Social.php
+++ b/Helper/Social.php
@@ -60,6 +60,6 @@ class Social extends HelperData
 
 	public function getBaseAuthUrl()
 	{
-		return $this->_getUrl('sociallogin/social/callback', array('_nosid' => true));
+		return($this->getCurrentScope() . 'sociallogin/social/callback' );
 	}
 }

--- a/view/frontend/web/js/sociallogin.js
+++ b/view/frontend/web/js/sociallogin.js
@@ -7,7 +7,7 @@ define(["prototype"], function () {
             this.outerWidth = typeof window.outerWidth != 'undefined' ? window.outerWidth : document.body.clientWidth;
             this.outerHeight = typeof window.outerHeight != 'undefined' ? window.outerHeight : (document.body.clientHeight - 22);
             this.width = w ? w : 500;
-            this.height = h ? h : 270;
+            this.height = h ? h : 420;
             this.left = l ? l : parseInt(this.screenX + ((this.outerWidth - this.width) / 2), 10);
             this.top = t ? t : parseInt(this.screenY + ((this.outerHeight - this.height) / 2.5), 10);
             this.features = (


### PR DESCRIPTION
1. Fixed the 'Invalid Return Type error...'.
2. Changed popup height to 420px, to avoid unnecessary scrollbar.
3. Added multiple-domains support, in case you have more than one domain under the same Magento system & you need different redirect URL for each...
4. Added a default 'displayName' on Google login controller, if it's empty - show 'NewUser'.