### PR TITLE
Remove user_about_me Facebook permission

### DIFF
--- a/Helper/Social.php
+++ b/Helper/Social.php
@@ -78,7 +78,7 @@ class Social extends HelperData
     public function getSocialConfig($type)
     {
         $apiData = [
-            'Facebook'  => ["trustForwarded" => false, 'scope' => 'email, user_about_me'],
+            'Facebook'  => ["trustForwarded" => false, 'scope' => 'email'],
             'Twitter'   => ["includeEmail" => true],
             'LinkedIn'  => ["fields" => ['id', 'first-name', 'last-name', 'email-address']],
             'Vkontakte' => ['wrapper' => ['class' => '\Mageplaza\SocialLogin\Model\Providers\Vkontakte']],


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

The facebook permission called "user_about_me" is deprecated:

https://developers.facebook.com/docs/facebook-login/permissions/#reference-user_about_me
