### PR TITLE
Wrong it_IT translation

### DIFF
--- a/i18n/it_IT.csv
+++ b/i18n/it_IT.csv
@@ -60,7 +60,7 @@
 "Ooophs, we got an error: %1","Ooophs, abbiamo ottenuto un errore: %1"
 "Or Sign In With","Oppure Accedi con"
 "Orange","arancia"
-"Password","Parola d'ordine"
+"Password","Password"
 "Phone Number","Numero di telefono"
 "Pink","Rosa"
 "Please correct the email address.","Correggi l'indirizzo email."


### PR DESCRIPTION
### Description
Correction for the italian translation file.

In italian the word "Password" remain as is in english.

Please accept this pull request. 