### PR TITLE
add event dispacher [customer_register_success]

### DIFF
--- a/Controller/Social/AbstractSocial.php
+++ b/Controller/Social/AbstractSocial.php
@@ -166,6 +166,12 @@ abstract class AbstractSocial extends Action
         if (!$customer->getId()) {
             try {
                 $customer = $this->apiObject->createCustomerSocial($user, $this->getStore());
+
+                $this->_eventManager->dispatch(
+                    'customer_register_success',
+                    ['account_controller' => $this, 'customer' => $customer]
+                );
+
             } catch (\Exception $e) {
                 $this->emailRedirect($e->getMessage(), false);
 


### PR DESCRIPTION
Add Event dispatcher to success customer registration from Mageplaza 2 Social Login plugin

### Description
When Social login extension creates new user, custom functions who listen to **customer_register_success** doesn`t fire up.

### Manual testing scenarios
1. Register new function with **customer_register_success** event.
2. Register account via Social Login plugin.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
