### PR TITLE
Removed 'status' filter

### DIFF
--- a/Model/Social.php
+++ b/Model/Social.php
@@ -160,7 +160,6 @@ class Social extends AbstractModel
         $socialCustomer = $this->getCollection()
             ->addFieldToFilter('social_id', $identify)
             ->addFieldToFilter('type', $type)
-            ->addFieldToFilter('status', ['null' => 'true'])
             ->getFirstItem();
 
         if ($socialCustomer && $socialCustomer->getId()) {
@@ -376,7 +375,6 @@ class Social extends AbstractModel
             ->addFieldToSelect('social_customer_id')
             ->addFieldToFilter('type', $type)
             ->addFieldToFilter('social_id', base64_decode($identifier))
-            ->addFieldToFilter('status', self::STATUS_LOGIN)
             ->getFirstItem();
     }
 


### PR DESCRIPTION
'status' column does not exist in social model
 
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
In methods getCustomerBySocial and getUser, a filter applied to the collection on 'status', which produces an error since status column is not present in table 'mageplaza_social_customer'

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Call getCustomerBySocial to get a customer created by a social account (eg: Linkedin)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
