### PR TITLE
Alternative fix for 'status' field causing error

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -54,6 +54,18 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
+        
+        if( version_compare($context->getVersion(), '1.1.1', '<') {
+            $connection->addColumn(
+                $tableName,
+                'status',
+                [
+                    'type'    => Table::TYPE_TEXT,
+                    'length'  => 255,
+                    'comment' => 'Status',
+                ]
+            );
+        }
 
         $installer->endSetup();
     }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -21,7 +21,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mageplaza_SocialLogin" setup_version="1.1.0">
+    <module name="Mageplaza_SocialLogin" setup_version="1.1.1">
         <sequence>
             <module name="Mageplaza_Core"/>
         </sequence>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description 
<!--- Provide a description of the changes proposed in the pull request -->
An alternative fix to https://github.com/mageplaza/magento-2-social-login/pull/174 as suggested by https://github.com/mageplaza/magento-2-social-login/issues/175#issuecomment-584101503

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. In methods getCustomerBySocial and getUser, a filter applied to the collection on 'status', which produces an error since status column is not present in table 'mageplaza_social_customer'

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Call getCustomerBySocial to get a customer created by a social account (eg: Linkedin)

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
