### PR TITLE
Fix redirect URL handling

### DIFF
--- a/Controller/Social/AbstractSocial.php
+++ b/Controller/Social/AbstractSocial.php
@@ -240,7 +240,7 @@ abstract class AbstractSocial extends Action
             }
         }
 
-        $object = ObjectManager::getInstance()->create(DataObject::class, ['url' => $url]);
+        $object = new DataObject(['url' => $url]);
         $this->_eventManager->dispatch(
             'social_manager_get_login_redirect',
             [


### PR DESCRIPTION
### Description
When redirecting after authentication, there is code that attempted to get the correct redirect URL, but always returned null. It should now return the correct URL based on the logic above the changed line.

### Fixed Issues
Not reported as a separate issue yet, but there is currently a bug where the custom URL determined in the `_loginPostRedirect` method is reset to null due to how the `DataObject` is instantiated.

### Manual testing scenarios
1. Start a login flow with the redirect cookie set
2. See that you are redirected to the location in the cookie instead of `/customer/account`. 

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
