### PR TITLE
add website id to mageplaza_social_customer and login process

### DIFF
--- a/Controller/Social/Login.php
+++ b/Controller/Social/Login.php
@@ -71,7 +71,6 @@ class Login extends AbstractSocial
         }
 
         $customer     = $this->apiObject->getCustomerBySocial($userProfile->identifier, $type);
-        $customerData = $this->customerModel->load($customer->getId());
 
         if (!$customer->getId()) {
             $requiredMoreInfo = (int)$this->apiHelper->requiredMoreInfo();
@@ -91,6 +90,8 @@ class Login extends AbstractSocial
 
             $customer = $this->createCustomerProcess($userProfile, $type);
         } elseif ($this->apiHelper->isCheckMode()) {
+            $customerData = $this->customerModel->load($customer->getId());
+
             if ($customerData->getData('password_hash') === null) {
                 $userProfile->hash = '';
                 $this->session->setUserProfile($userProfile);

--- a/Model/Social.php
+++ b/Model/Social.php
@@ -160,6 +160,7 @@ class Social extends AbstractModel
         $socialCustomer = $this->getCollection()
             ->addFieldToFilter('social_id', $identify)
             ->addFieldToFilter('type', $type)
+            ->addFieldToFilter('website_id', $this->storeManager->getWebsite()->getId())
             ->addFieldToFilter('status', ['null' => 'true'])
             ->getFirstItem();
 
@@ -280,6 +281,7 @@ class Social extends AbstractModel
                 'social_id'              => $identifier,
                 'customer_id'            => $customerId,
                 'type'                   => $type,
+                'website_id'             => $this->storeManager->getWebsite()->getId(),
                 'is_send_password_email' => $this->apiHelper->canSendPassword(),
                 'social_created_at'      => $this->_dateTime->date()
             ]

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -74,6 +74,27 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     Table::ACTION_CASCADE
                 );
             }
+            if ($connection->tableColumnExists($tableName, 'website_id') === false) {
+                $connection->addColumn(
+                    $tableName,
+                    'website_id',
+                    5,
+                    [
+                        'type' => Table::TYPE_INTEGER,
+                        'nullable' => false,
+                        'unsigned' => true,
+                        'comment' => 'Website Id',
+                    ]
+                );
+                $connection->addForeignKey(
+                    $installer->getFkName('mageplaza_social_website', 'website_id', 'core_website', 'website_id'),
+                    $tableName,
+                    'website_id',
+                    $installer->getTable('core_website'),
+                    'website_id',
+                    Table::ACTION_CASCADE
+                );
+            }
             if ($connection->tableColumnExists($tableName, 'status') === false) {
                 $connection->addColumn(
                     $tableName,


### PR DESCRIPTION
The website_id field has been added to the login process to avoid conflict when the same social user logs in on different Magento websites

### Fixed Issues (if relevant)
1. https://github.com/mageplaza/magento-2-social-login/issues/229
