### PR TITLE
Remove invalid "checkout" reference in CMS layout

### DIFF
--- a/view/frontend/layout/cms_index_index.xml
+++ b/view/frontend/layout/cms_index_index.xml
@@ -20,8 +20,7 @@
  * @license     https://www.mageplaza.com/LICENSE.txt
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout"
-      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
             <block class="Mageplaza\SocialLogin\Block\DataDeletion\DeleteData" name="social-login-popup-delete-data"


### PR DESCRIPTION
### Description
The `cms_index_index.xml` layout file is incorrectly specifying to use the `checkout` layout. This does not appear intentional and should not need to be set here by this module? It should be set elsewhere in the theme etc.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
