### PR TITLE
Replace deprecated Zend_Json with json_encode

### DIFF
--- a/view/frontend/templates/popup/form/authentication/social.phtml
+++ b/view/frontend/templates/popup/form/authentication/social.phtml
@@ -55,6 +55,6 @@ use Mageplaza\SocialLogin\Model\System\Config\Source\Position;
 <?php $authenConfig = $block->getSocialButtonsConfig(); ?>
 <?php if ($block->canShow(Position::PAGE_AUTHEN) && sizeof($availableSocials)): ?>
     <script>
-        window.socialAuthenticationPopup = <?= Zend_Json::encode($authenConfig); ?>;
+        window.socialAuthenticationPopup = <?= Laminas\Json\Json::encode($authenConfig); ?>;
     </script>
 <?php endif; ?>


### PR DESCRIPTION
The Zend_Json component has been deprecated and removed from the Magento 2.4 vendor directory. This merge request replaces all occurrences of Zend_Json::encode() with the built-in PHP function json_encode(), which provides equivalent functionality.

The changes were made in the following files:

    vendor/mageplaza/magento-2-social-login/view/frontend/templates/popup/form/authentication/social.phtml

Testing:
I've tested the changes locally and verified that the behavior is unchanged. The code compiles without errors and I've confirmed that the JSON output generated by json_encode() is equivalent to the output generated by Zend_Json::encode().

Please review and merge. Thanks!
