### PR TITLE
fix inline scripts according to CSP restrictions

### DIFF
--- a/view/frontend/templates/broadcast_channel.phtml
+++ b/view/frontend/templates/broadcast_channel.phtml
@@ -18,44 +18,54 @@
  * @copyright   Copyright (c) Mageplaza (https://www.mageplaza.com/)
  * @license     https://www.mageplaza.com/LICENSE.txt
  */
+
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 $helperData = $this->helper(\Mageplaza\SocialLogin\Helper\Data::class);
 ?>
-<script>
-    let channel = new BroadcastChannel('social-login-channel');
 
-    channel.onmessage = function (event) {
-        if (event.data.event === 'socialLoginSuccess') {
-            window.MP_ACCESS_TOKEN_KEY = event.data.customerToken;
-            window.location.reload();
-        }
+<?php
+$scriptString = <<<script
+            let channel = new BroadcastChannel('social-login-channel');
 
-        if (event.data.event === 'loginRedirect') {
-            if (event.data.data.redirectUrl) {
-                window.location.href = event.data.data.redirectUrl;
-            } else {
-                window.location.href = event.data.redirectUrl;
-            }
-        }
+            channel.onmessage = function (event) {
+                if (event.data.event === 'socialLoginSuccess') {
+                    window.MP_ACCESS_TOKEN_KEY = event.data.customerToken;
+                    window.location.reload();
+                }
 
-        if (event.data.event === 'windowClose') {
-            window.location.reload();
-        }
+                if (event.data.event === 'loginRedirect') {
+                    if (event.data.data.redirectUrl) {
+                        window.location.href = event.data.data.redirectUrl;
+                    } else {
+                        window.location.href = event.data.redirectUrl;
+                    }
+                }
 
-        if (event.data.event === 'requiredMoreInfo') {
-            if (event.data.data.customerToken) {
-                window.MP_ACCESS_TOKEN_KEY = event.data.data.customerToken;
-            }
-            <?php if(!$helperData->checkHyvaTheme()): ?>
-            if (typeof window.fakeEmailCallback !== 'undefined') {
-                fakeEmailCallback(
-                    event.data.data.type,
-                    event.data.data.firstName,
-                    event.data.data.lastName,
-                    event.data.data.typeEmail ?? ''
-                );
-            }
-            window.close();
-            <?php else: ?>
+                if (event.data.event === 'windowClose') {
+                    window.location.reload();
+                }
+
+                if (event.data.event === 'requiredMoreInfo') {
+                    if (event.data.data.customerToken) {
+                        window.MP_ACCESS_TOKEN_KEY = event.data.data.customerToken;
+                    } 
+            script;
+            if(!$helperData->checkHyvaTheme()):
+                $scriptString .= <<<script
+                if (typeof window.fakeEmailCallback !== 'undefined') {
+                    fakeEmailCallback(
+                        event.data.data.type,
+                        event.data.data.firstName,
+                        event.data.data.lastName,
+                        event.data.data.typeEmail ?? ''
+                    );
+                }
+                window.close();
+                script;
+            else:
+                $scriptString .= <<<script
             document.querySelector('.social-login.authentication').style.display = 'none';
             document.querySelector('.social-login.forgot').style.display         = 'none';
             document.querySelector('.social-login.create').style.display         = 'none';
@@ -95,16 +105,22 @@ $helperData = $this->helper(\Mageplaza\SocialLogin\Helper\Data::class);
                 lastNameInput.value = event.data.data.lastName;
                 form.appendChild(lastNameInput);
             }
-            <?php endif;?>
+            script;
+            endif;
+            $scriptString .= <<<script
         }
     };
-    <?php if(!$helperData->checkHyvaTheme()): ?>
-    function openLoginPopup () {
-        let currentTime = new Date().toISOString();
-        channel.postMessage({
-            event: 'openPopup',
-            time: currentTime
-        });
-    }
-    <?php endif;?>
-</script>
+    script;
+    if(!$helperData->checkHyvaTheme()):
+        $scriptString .= <<<script
+            function openLoginPopup () {
+                let currentTime = new Date().toISOString();
+                channel.postMessage({
+                    event: 'openPopup',
+                    time: currentTime
+                });
+            }
+        script;
+    endif;
+?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>

--- a/view/frontend/templates/popup/form/create.phtml
+++ b/view/frontend/templates/popup/form/create.phtml
@@ -18,7 +18,9 @@
  * @copyright   Copyright (c) Mageplaza (https://www.mageplaza.com/)
  * @license     https://www.mageplaza.com/LICENSE.txt
  */
-/** @var \Mageplaza\SocialLogin\Block\Form\Register $block */
+/** @var \Mageplaza\SocialLogin\Block\Form\Register $block
+ ** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
 ?>
 <div class="social-login block-container create" style="display: none">
     <div class="social-login-title">
@@ -218,34 +220,44 @@
                     </div>
                 </div>
             </form>
-            <script>
-                require([
-                    'jquery',
-                    'mage/mage'
-                ], function ($) {
-                    var dataForm = $('#social-form-create'),
-                        ignore = <?= $_dob->isEnabled() ? '\'input[id$="full"]\'' : 'null' ?>;
+            <?php
+                $ignore = /* @noEscape */ $_dob->isEnabled() ? "'input[id$=\"full\"]'" : 'null';
+                $scriptString = <<<script
+                    require([
+                        'jquery',
+                        'mage/mage'
+                    ], function($) {
+                        var dataForm = $('#social-form-create'),
+                            ignore = {$ignore};
 
-                    dataForm.mage('validation', {
-                        <?php if ($_dob->isEnabled()): ?>
-                        errorPlacement: function (error, element) {
-                            if (element.prop('id').search('full') !== -1) {
-                                var dobElement = $(element).parents('.customer-dob'),
-                                    errorClass = error.prop('class');
-                                error.insertAfter(element.parent());
-                                dobElement.find('.validate-custom').addClass(errorClass)
-                                    .after('<div class="' + errorClass + '"></div>');
-                            } else {
-                                error.insertAfter(element);
-                            }
-                        },
-                        ignore: ':hidden:not(' + ignore + ')'
-                        <?php else: ?>
-                        ignore: ignore ? ':hidden:not(' + ignore + ')' : ':hidden'
-                        <?php endif ?>
+                        dataForm.mage('validation', {
+                    script;
+                    if ($_dob->isEnabled()) {
+                        $scriptString .= <<<script
+                            errorPlacement: function(error, element) {
+                                if (element.prop('id').search('full') !== -1) {
+                                    var dobElement = $(element).parents('.customer-dob'),
+                                        errorClass = error.prop('class');
+                                    error.insertAfter(element.parent());
+                                    dobElement.find('.validate-custom').addClass(errorClass)
+                                        .after('<div class="' + errorClass + '"></div>');
+                                } else {
+                                    error.insertAfter(element);
+                                }
+                            },
+                            ignore: ':hidden:not(' + ignore + ')'
+                    script;
+                    } else {
+                        $scriptString .= <<<script
+                            ignore: ignore ? ':hidden:not(' + ignore + ')' : ':hidden'
+                    script;
+                    }
+                    $scriptString .= <<<script
+                        });
                     });
-                });
-            </script>
+                    script;
+            ?>
+            <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
             <?php if ($block->getShowAddressFields()): ?>
                 <script type="text/x-magento-init">
                     {

--- a/view/frontend/templates/popup/form/social_buttons.phtml
+++ b/view/frontend/templates/popup/form/social_buttons.phtml
@@ -19,6 +19,10 @@
  * @license     https://www.mageplaza.com/LICENSE.txt
  */
 
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ */
+
 use Mageplaza\SocialLogin\Model\System\Config\Source\Position;
 
 ?>
@@ -43,12 +47,15 @@ $availableSocials = $block->getAvailableSocials(); ?>
             </div>
         </div>
     </div>
-
-    <script type="text/javascript">
-        require(['jquery'], function ($) {
-            $('.mp-social-popup').addClass('col-mp mp-7');
-        });
-    </script>
+    
+    <?php 
+        $scriptString = <<<script
+                    require(['jquery'], function ($) {
+                $('.mp-social-popup').addClass('col-mp mp-7');
+            });
+        script; 
+    ?>
+    <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 <?php endif; ?>
 
 <?php
@@ -58,7 +65,8 @@ $availableSocials = $block->getAvailableSocials(); ?>
 ?>
 <?php $authenConfig = $block->getSocialButtonsConfig(); ?>
 <?php if ($block->canShow(Position::PAGE_AUTHEN) && sizeof($availableSocials)): ?>
-    <script>
-        window.socialAuthenticationPopup = <?= \Laminas\Json\Json::encode($authenConfig); ?>;
-    </script>
+    <?php
+        $authScript = 'window.socialAuthenticationPopup = ' . \Laminas\Json\Json::encode($authenConfig) . ';';
+        echo $secureRenderer->renderTag('script', [], $authScript, false);
+    ?>
 <?php endif; ?>


### PR DESCRIPTION
Fix inline scripts to comply with CSP restrictions
### Description
This pull request addresses the issue of inline JavaScript used in the Mageplaza Social Login module, which was blocked by Magento 2's Content Security Policy (CSP).

### Fixed Issues (if relevant)
No related issue number provided, but the PR fixes general CSP compatibility problems when using Mageplaza Social Login in Magento 2 stores with CSP enabled.

### Manual testing scenarios
Enable CSP in Magento 2 (e.g., Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self').

Install and enable the Mageplaza Social Login module with this fix.

Visit the login/register page and verify:

No CSP violations in browser dev tools.

Social login buttons work as expected (e.g., popup behavior, redirects).

Test with all supported providers (Google, Facebook, etc.).

### Contribution checklist
 - [x]  Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable) - not applicable here due to frontend nature of changes.

